### PR TITLE
Add xterm-256color support.

### DIFF
--- a/source/consolecolors.d
+++ b/source/consolecolors.d
@@ -1110,11 +1110,14 @@ version(Windows)
     {
         try
         {   
-            if (environment.get("TERM") !is null)
+            string term = environment.get("TERM");
+            if (term !is null)
             {
                 // Assume we are supporting VT100 here.
                 // This covers Git Bash with MinTTY (See Issue #7)
-                return environment.get("TERM") == "xterm";
+                // Its usable TERM variable can be these according to
+                // https://wiki.archlinux.org/title/Xterm#TERM_Environmental_Variable
+                return term == "xterm" || term == "xterm-256color";
             }
         }
         catch(Exception e)


### PR DESCRIPTION
Related to #7
![image](https://user-images.githubusercontent.com/57452864/192086310-8b48136e-2e7d-4f06-9571-ae8d7716d64b.png)

My mintty sets TERM=xterm-256color for emacs/vim but cwrite(...) showed nothing then. I think the xterm-256color is common enough to support:
>  Two usable terminfo names are xterm and xterm-256color
https://wiki.archlinux.org/title/Xterm#TERM_Environmental_Variable